### PR TITLE
Unbreak build on GCC 10

### DIFF
--- a/GLideN64/src/ShaderUtils.cpp
+++ b/GLideN64/src/ShaderUtils.cpp
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stdio.h>
+#include <string>
 #include "ShaderUtils.h"
 #include "Config.h"
 #include "Log.h"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ INCFLAGS  :=
 COREFLAGS :=
 CPUFLAGS  :=
 GLFLAGS   :=
+XTRAFLAGS := -fcommon
 
 UNAME=$(shell uname -a)
 
@@ -400,7 +401,7 @@ endif
 
 OBJECTS     += $(SOURCES_CXX:.cpp=.o) $(SOURCES_C:.c=.o) $(SOURCES_ASM:.S=.o) $(SOURCES_NASM:.asm=.o)
 CXXFLAGS    += $(CPUOPTS) $(COREFLAGS) $(INCFLAGS) $(PLATCFLAGS) $(fpic) $(CPUFLAGS) $(GLFLAGS) $(DYNAFLAGS)
-CFLAGS      += $(CPUOPTS) $(COREFLAGS) $(INCFLAGS) $(PLATCFLAGS) $(fpic) $(CPUFLAGS) $(GLFLAGS) $(DYNAFLAGS)
+CFLAGS      += $(XTRAFLAGS) $(CPUOPTS) $(COREFLAGS) $(INCFLAGS) $(PLATCFLAGS) $(fpic) $(CPUFLAGS) $(GLFLAGS) $(DYNAFLAGS)
 
 ifeq (,$(findstring android,$(platform)))
    LDFLAGS    += -lpthread


### PR DESCRIPTION
Enforce pre-GCC 10 default -fcommon CFLAG and add missing include to unbreak build in GCC 10.x environments such as Ubuntu 20.10 (see GCC 10 porting guidance: https://gcc.gnu.org/gcc-10/porting_to.html). 